### PR TITLE
Bounded batch process

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ provides a batch of the given size, or every time the timeout elapses,
 whichever comes first.
 
 ```clj
-(batch-process ch prn 4 1000)
+(batch-process ch prn
+               {:batch-size 4
+                :timeout 1000
+                :wrapup-f #(println "Done!")})
 (async/onto-chan ch (range 10) false)
 (Thread/sleep 2000)
 (async/>!! ch 10)
@@ -25,10 +28,21 @@ That will end up printing:
 [4 5 6 7]
 [8 9]
 [10]
+Done!
 ```
 
-You may call `batch-process` with an optional 0-arity function which
-will be called when the channel has been closed and emptied.
+The options `batch-process` takes are:
+
+* `:batch-size`: The number of messages required to trigger a call of
+  the processing function. Default: 100.
+* `:timeout`: The number of milliseconds to trigge a call of the
+  processing function even if the number of messages hasn't reached
+  the batch size. Default: 5000.
+* `:wrapup-f`: A 0-arity function to call once the channel is closed
+  and jobs have completed.
+* `:pool-size`: The number of threads to use for processing
+  messages. Work will block when all threads are occupied. If nil,
+  will use core.async's thread pool, which is unbounded. Default: nil.
 
 ## License
 

--- a/java-src/utility_works/async/BoundedExecutor.java
+++ b/java-src/utility_works/async/BoundedExecutor.java
@@ -1,0 +1,30 @@
+package utility_works.async;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class BoundedExecutor extends ThreadPoolExecutor {
+
+  private final Semaphore semaphore;
+
+  public BoundedExecutor(int bound) {
+    super(bound, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>());
+    semaphore = new Semaphore(bound, true);
+  }
+
+  public <T> Future<T> blockingSubmit(final Callable<T> task) throws InterruptedException {
+    semaphore.acquire();
+    return submit(task);
+  }
+
+  @Override
+  protected void afterExecute(Runnable r, Throwable t) {
+    super.afterExecute(r, t);
+
+    semaphore.release();
+  }
+}

--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,5 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.2.391"]]
   :deploy-repositories [["releases" :clojars]
-                        ["snapshots" :clojars]])
+                        ["snapshots" :clojars]]
+  :java-source-paths ["java-src"])

--- a/src/utility_works/async.clj
+++ b/src/utility_works/async.clj
@@ -1,34 +1,94 @@
 (ns utility-works.async
-  (:require [clojure.core.async :as a]))
+  (:require [clojure.core.async :as a])
+  (:import [utility_works.async BoundedExecutor]
+           [java.util.concurrent TimeUnit]))
+
+(def batch-process-defaults
+  {:batch-size 100
+   :timeout 5000
+   :pool-size nil
+   :wrapup-f (constantly nil)})
+
+(defn batch-process*
+  [ch f {:keys [batch-size timeout wrapup-f]}]
+  (a/go-loop [timeout-ch (a/timeout timeout)
+              messages []]
+    (if (= batch-size (count messages))
+      (do
+        (a/thread
+          (f messages))
+        (recur (a/timeout timeout)
+               []))
+      (a/alt!
+        ch ([message]
+            (if (nil? message)
+              (do
+                (when (seq messages)
+                  (f messages))
+                (wrapup-f))
+              (recur timeout-ch
+                     (conj messages message))))
+        timeout-ch (do
+                     (when (seq messages)
+                       (a/thread
+                         (f messages)))
+                     (recur (a/timeout timeout)
+                            []))))))
+
+(defn bounded-batch-process*
+  [ch f {:keys [batch-size timeout pool-size wrapup-f]}]
+  (a/thread
+    (let [executor (BoundedExecutor. pool-size)]
+      (loop [timeout-ch (a/timeout timeout)
+             messages []]
+        (if (= batch-size (count messages))
+          (do
+            (.blockingSubmit executor
+                             #(f messages))
+            (recur (a/timeout timeout)
+                   []))
+          (a/alt!!
+            ch ([message]
+                (if (nil? message)
+                  (do
+                    (when (seq messages)
+                      (.blockingSubmit executor
+                                       #(f messages)))
+                    (.shutdown executor)
+                    (.awaitTermination executor
+                                       (* 10 timeout)
+                                       TimeUnit/MILLISECONDS)
+                    (wrapup-f))
+                  (recur timeout-ch
+                         (conj messages message))))
+            timeout-ch (do
+                         (when (seq messages)
+                           (.blockingSubmit executor
+                                            #(f messages)))
+                         (recur (a/timeout timeout)
+                                []))))))))
 
 (defn batch-process
-  "Take from ch and call f on a seq of messages every batch-size
-  messages or every timeout milliseconds, whichever comes first. An
-  optional wrapup-f will be called after ch has been closed and
-  emptied."
-  ([ch f batch-size timeout]
-   (batch-process ch f batch-size timeout (constantly nil)))
-  ([ch f batch-size timeout wrapup-f]
-   (a/go-loop [timeout-ch (a/timeout timeout)
-               messages []]
-     (if (= batch-size (count messages))
-       (do
-         (a/thread
-           (f messages))
-         (recur (a/timeout timeout)
-                []))
-       (a/alt!
-         ch ([message]
-             (if (nil? message)
-               (do
-                 (when (seq messages)
-                   (f messages))
-                 (wrapup-f))
-               (recur timeout-ch
-                      (conj messages message))))
-         timeout-ch (do
-                      (when (seq messages)
-                        (a/thread
-                          (f messages)))
-                      (recur (a/timeout timeout)
-                             [])))))))
+  "Repatedly take from ch and call f on a seq of messages whenever a
+  threshold of messages has been collected or a timeout has been
+  reached, whichever comes first.
+
+  Options:
+  :batch-size  The number of messages to call the processing function on.
+               Default 100.
+  :timeout     The number of milliseconds to call the processing
+               function even if the batch-size has not been reached.
+               Default 5000.
+  :pool-size   The number of threads to use for processing. If nil,
+               will use core.async's thread pool, which is unbounded.
+               Default nil.
+  :wrapup-f    A 0-arity function to call once the channel has been closed
+               and all jobs have been submitted. Default (constantly nil)"
+  ([ch f]
+   (batch-process ch f batch-process-defaults))
+  ([ch f options]
+   (let [{:keys [pool-size] :as options}
+         (merge batch-process-defaults options)]
+     (if pool-size
+       (bounded-batch-process* ch f options)
+       (batch-process* ch f options)))))

--- a/test/utility_works/async_test.clj
+++ b/test/utility_works/async_test.clj
@@ -11,12 +11,12 @@
           messages (a/chan 100)]
       (batch-process messages
                      (partial swap! result conj)
-                     4
-                     100
-                     (fn []
-                       (reset! timing
-                               (- (System/currentTimeMillis)
-                                  start-time))))
+                     {:batch-size 4
+                      :timeout 100
+                      :wrapup-f (fn []
+                                  (reset! timing
+                                          (- (System/currentTimeMillis)
+                                             start-time)))})
 
       (a/onto-chan messages (range 10) false)
       (Thread/sleep 120)
@@ -27,6 +27,7 @@
       (a/>!! messages 10)
 
       (a/close! messages)
+      (Thread/sleep 20)
 
       (is (= [[0 1 2 3]
               [4 5 6 7]
@@ -39,4 +40,38 @@
              @result))
 
       (testing "calls the wrapup-f afterwards"
-        (is (< 480 @timing))))))
+        (is (< 480 @timing)))))
+
+  (testing "with a bounded thread pool"
+    (let [result (atom #{})
+          timing (atom nil)
+          start-time (System/currentTimeMillis)
+          messages (a/chan 100)
+
+          processing-ch
+          (batch-process messages
+                         (fn [messages]
+                           (Thread/sleep 250)
+                           (swap! result conj messages))
+                         {:batch-size 4
+                          :timeout 100
+                          :pool-size 2
+                          :wrapup-f (fn []
+                                      (reset! timing
+                                              (- (System/currentTimeMillis)
+                                                 start-time)))})]
+
+      (a/onto-chan messages (range 17))
+
+      ;; Wait for the work to finish
+      (a/<!! processing-ch)
+
+      (is (= #{[0 1 2 3]
+               [4 5 6 7]
+               [8 9 10 11]
+               [12 13 14 15]
+               [16]}
+             @result))
+
+      (testing "calls the wrapup-f after all the work is done"
+        (is (< 750 @timing 800))))))


### PR DESCRIPTION
Refactors batch-process to take an options map for everything except the channel and processing function (there's no possible defaults for those!).

The options are:
* `:batch-size`: The number of messages required to trigger a call of the processing function. Default: 100.
* `:timeout`: The number of milliseconds to trigger a call of the processing function even if the number of messages hasn't reached the batch size. Default: 5000.
* `:wrapup-f`: A 0-arity function to call once the channel is closed and jobs have completed.
* `:pool-size`: The number of threads to use for processing messages. Work will block when all threads are occupied. If nil, will use core.async's thread pool, which is unbounded. Default: nil.

Pushed to Clojars as 0.1.3.bounded-SNAPSHOT.